### PR TITLE
sysfs initialization of INA226 sensors' critical high power limitations on the BH motherboard

### DIFF
--- a/hwmon.hpp
+++ b/hwmon.hpp
@@ -16,6 +16,7 @@ static constexpr auto cenable = "enable";
 static constexpr auto cfault = "fault";
 static constexpr auto caverage = "average";
 static constexpr auto caverage_interval = "average_interval";
+static constexpr auto ccritical = "crit";
 
 static const std::string input = cinput;
 static const std::string label = clabel;
@@ -24,6 +25,7 @@ static const std::string enable = cenable;
 static const std::string fault = cfault;
 static const std::string average = caverage;
 static const std::string average_interval = caverage_interval;
+static const std::string critical = ccritical;
 } // namespace entry
 
 namespace type

--- a/mainloop.cpp
+++ b/mainloop.cpp
@@ -354,6 +354,23 @@ void MainLoop::init()
             _state[std::move(i.first)] = std::move(value);
         }
 
+        // Initialize power critical value to sys filesystem
+        if ((i.first.first == hwmon::type::power) && 
+            i.second.find(hwmon::entry::critical) != i.second.end())
+        {
+            const auto& [sensorSysfsType, sensorSysfsNum] = i.first;
+        
+            // Write power critical value to sensor.
+            std::string crit = hwmon::entry::critical;
+
+            // Read power critical high value from environment
+            auto tHi = env::getEnv(Thresholds<CriticalObject>::envHi, 
+                    sensorSysfsType, sensorSysfsNum);
+
+            _ioAccess->write(std::stoi(tHi), sensorSysfsType, sensorSysfsNum, crit, 
+                    hwmonio::retries, hwmonio::delay);
+        }
+
         // Initialize _averageMap of sensor. e.g. <<power, 1>, <0, 0>>
         if ((i.first.first == hwmon::type::power) &&
             (phosphor::utility::isAverageEnvSet(i.first)))

--- a/mainloop.cpp
+++ b/mainloop.cpp
@@ -367,7 +367,8 @@ void MainLoop::init()
             auto tHi = env::getEnv(Thresholds<CriticalObject>::envHi, 
                     sensorSysfsType, sensorSysfsNum);
 
-            _ioAccess->write(std::stoi(tHi), sensorSysfsType, sensorSysfsNum, crit, 
+            if(!tHi.empty())
+                _ioAccess->write(std::stoi(tHi), sensorSysfsType, sensorSysfsNum, crit, 
                     hwmonio::retries, hwmonio::delay);
         }
 


### PR DESCRIPTION
Support to read critical high power limitation from environment variables and to update /sys/class/hwmon/hwmon/power1_crit during D-Bus sensor initialization